### PR TITLE
Remove message from top of readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,3 @@
-MATCHCODE TOOLKIT HAS BEEN MOVED TO https://github.com/aboutcode-org/matchcode-toolkit 
-======================================================================================
-
-
 MatchCode toolkit
 =================
 MatchCode toolkit is a Python library that provides the file and directory


### PR DESCRIPTION
This PR removes the project relocation message at the top of the readme.